### PR TITLE
Add unit of seconds to track.length

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -225,7 +225,7 @@ Tracks **MAY** have these keys:
 These optional fields reflect audio metadata:
 
 * ``type``, string: The MIME type of the associated audio file.
-* ``length``, integer: The duration of the audio in seconds.
+* ``length``, integer: The duration of the audio in milliseconds.
 * ``samplerate``, integer: The number of samples per second in the audio.
 * ``bitrate``, integer: The number of bits per second in the encoding.
 * ``bitdepth``, integer: The number of bits per sample.


### PR DESCRIPTION
The optional `length` field of track resources should have a time unit specified. Since it's an optional, nice-to-have field, precision is probably not important -- so I guess we're talking _seconds_ here... right?
