### PR TITLE
Clarified behaviour when a filter fails

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -202,11 +202,14 @@ respond with only those resources whose ``key`` field exactly matches
 ``value``.
 
 For example, the request ``/aura/tracks?filter[title]=Blackbird`` finds the
-track titled "Blackbird."
+track titled "Blackbird".
 
 Filtering is by exact match only (i.e., no substring or case-insensitive
 matching is performed). More flexible queries may be eventually be specified
 in an AURA extension.
+
+If there are no exact matches, or if the server does not support filtering by
+the given key, then the ``data`` key of the response should be an empty array.
 
 Pagination
 ''''''''''


### PR DESCRIPTION
If there are no matches for a filter, or if the server does not support filtering by the given key (say `bpm`, which is optional), then the returned data should be an empty array.
See #25.

(Also I changed `"Blackbird."` to `"Blackbird".` because I think it is clearer that the title is just `Blackbird` rather than `Blackbird.`, although I doubt anyone would have thought otherwise :-)